### PR TITLE
socks: fix nil pointer panic in login on connection error

### DIFF
--- a/socks/main.go
+++ b/socks/main.go
@@ -397,6 +397,9 @@ func login(ctx context.Context, apiURL, userAuth, password string) (string, erro
 	)
 
 	res := <-resChan
+	if res.err != nil {
+		return "", res.err
+	}
 	if res.res.Error != nil {
 		return "", errors.New(res.res.Error.Message)
 	}


### PR DESCRIPTION
The login function receives the API result through a channel callback.

When the underlying HTTP request fails (timeout, DNS failure, connection refused), the callback returns (nil, error). The code then accesses `res.res.Error` without checking `res.err` first, causing a nil pointer dereference panic:

```
panic: runtime error: invalid memory address or nil pointer dereference

goroutine 1 [running]:
main.login(...)
        github.com/urnetwork/proxy/v2026/socks/main.go:400 +0x298
main.main.func1(...)
        github.com/urnetwork/proxy/v2026/socks/main.go:120 +0x65
github.com/urfave/cli/v2.(*Command).Run(...)
        github.com/urfave/cli/v2@v2.27.7/command.go:276 +0x7c2
github.com/urfave/cli/v2.(*App).RunContext(...)
        github.com/urfave/cli/v2@v2.27.7/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
        github.com/urfave/cli/v2@v2.27.7/app.go:307
github.com/urfave/cli/v2.(*App).RunAndExitOnError(...)
        github.com/urfave/cli/v2@v2.27.7/app.go:384 +0x3f
main.main()
        github.com/urnetwork/proxy/v2026/socks/main.go:248 +0x845
```

Add the missing error check before accessing the result struct.

```diff
 	res := <-resChan
+	if res.err != nil {
+		return "", res.err
+	}
 	if res.res.Error != nil {
 		return "", errors.New(res.res.Error.Message)
 	}
```

This fix is a logical correction based on code review. It could not be end-to-end tested because the API was in a degraded state at the time of writing.
