### PR TITLE
fix: restore no-auth SOCKS5 when ValidUser is nil

### DIFF
--- a/socks.go
+++ b/socks.go
@@ -68,9 +68,16 @@ type SocksProxy struct {
 	// counters are the only observability the data path has, since it never logs.
 	//
 	// Building it lazily rather than in the constructor is what lets a caller adjust
-	// Settings() after construction and still have it take effect.
-	serverOnce   sync.Once
-	server       *socksServer
+	// Settings() after construction and still have it take effect. The freeze point
+	// is the first build — ensureServer — not serving start.
+	//
+	// serverMu guards both serverOnce and server so a read-only accessor can check
+	// whether the server exists without building it (building would freeze the
+	// configuration mid-setup). Once built, server is never replaced.
+	serverOnce sync.Once
+	serverMu   sync.Mutex
+	server     *socksServer
+
 	statsLogOnce sync.Once
 
 	ConnectDialWithRequest func(ctx context.Context, r SocksRequest, network string, addr string) (net.Conn, error)
@@ -101,8 +108,13 @@ func (self *SocksProxy) logger() connect.Logger {
 // Stats returns the socks data path's counters. Nothing on that path logs — a
 // client picks the rate, so logging would let it drive unbounded server I/O — so
 // these counters are how drops, dial failures and oversize datagrams are observed.
+// Read-only: it does not build the server, so reading it cannot freeze the
+// configuration. Zero values are returned before the server exists.
 func (self *SocksProxy) Stats() SocksStatsSnapshot {
-	return self.ensureServer().Stats().Snapshot()
+	if server := self.builtServer(); server != nil {
+		return server.Stats().Snapshot()
+	}
+	return SocksStatsSnapshot{}
 }
 
 // Drain begins a graceful drain (PROXYDRAIN1.md §3.2): listeners close while
@@ -113,9 +125,13 @@ func (self *SocksProxy) Drain() {
 	self.ensureServer().drain.Drain()
 }
 
-// ActiveCount reports the number of in-flight connections.
+// ActiveCount reports the number of in-flight connections. Read-only: it does
+// not build the server, so reading it cannot freeze the configuration.
 func (self *SocksProxy) ActiveCount() int {
-	return self.ensureServer().drain.ActiveCount()
+	if server := self.builtServer(); server != nil {
+		return server.drain.ActiveCount()
+	}
+	return 0
 }
 
 // WaitIdle blocks until a drain has begun and no connections are active, or
@@ -124,36 +140,50 @@ func (self *SocksProxy) WaitIdle(ctx context.Context) bool {
 	return self.ensureServer().drain.WaitIdle(ctx)
 }
 
+// builtServer returns the server if it has already been built, or nil. Read-only
+// accessors use this so that reading a counter cannot freeze the configuration.
+func (self *SocksProxy) builtServer() *socksServer {
+	self.serverMu.Lock()
+	defer self.serverMu.Unlock()
+	return self.server
+}
+
 // ensureServer builds the socks5 server on first use. Settings are read here, so
-// a caller may adjust Settings() any time before serving starts.
+// a caller may adjust Settings() any time before the first build.
 func (self *SocksProxy) ensureServer() *socksServer {
 	self.serverOnce.Do(func() {
+		self.serverMu.Lock()
+		defer self.serverMu.Unlock()
 		self.server = self.newServer()
 	})
 	return self.server
 }
 
 // newServer builds the socks5 protocol server. The callbacks recover panics via
-// connect.HandleError, matching the behavior the proxy has always had.
+// connect.HandleError, matching the behavior the proxy has always had. Callback
+// fields (ConnectDialWithRequest, ValidUser) are captured at build time so the
+// configuration freezes atomically with the build; reading them dynamically
+// inside the closures would race a concurrent assignment.
 func (self *SocksProxy) newServer() *socksServer {
 	server := newSocksServer(self.settings)
 	server.Log = self.logger()
+	dial := self.ConnectDialWithRequest
 	server.Dial = func(ctx context.Context, r *Request, network string, addr string) (net.Conn, error) {
 		return connect.HandleError2(func() (net.Conn, error) {
-			return self.ConnectDialWithRequest(ctx, r, network, addr)
+			return dial(ctx, r, network, addr)
 		}, func() (net.Conn, error) {
 			return nil, fmt.Errorf("Unexpected error")
 		})
 	}
-	server.ValidUser = func(user string, password string, userAddr string) bool {
-		if self.ValidUser == nil {
-			return false
+	// nil ValidUser means no-auth allowed, preserving pre-rewrite behavior
+	if validUser := self.ValidUser; validUser != nil {
+		server.ValidUser = func(user string, password string, userAddr string) bool {
+			return connect.HandleError1(func() bool {
+				return validUser(user, password, userAddr)
+			}, func() bool {
+				return false
+			})
 		}
-		return connect.HandleError1(func() bool {
-			return self.ValidUser(user, password, userAddr)
-		}, func() bool {
-			return false
-		})
 	}
 	return server
 }

--- a/socks/main.go
+++ b/socks/main.go
@@ -56,7 +56,7 @@ Usage:
     socksproxy [options]
 
 Options:
-    --addr=<addr>                  socks5 server address (env ADDR, default :9999)
+    --addr=<addr>                  socks5 server address (env ADDR, default 127.0.0.1:9999)
     --api-url=<api-url>            api url (env API_URL, default https://api.bringyour.com)
     --platform-url=<platform-url>  platform url (env PLATFORM_URL, default wss://connect.bringyour.com)
     --user-auth=<user-auth>        user auth, required (env USER_AUTH)
@@ -89,7 +89,7 @@ Options:
 		}
 		return def
 	}
-	cfg.addr = pick("--addr", "ADDR", ":9999")
+	cfg.addr = pick("--addr", "ADDR", "127.0.0.1:9999")
 	cfg.apiURL = pick("--api-url", "API_URL", "https://api.bringyour.com")
 	cfg.platformURL = pick("--platform-url", "PLATFORM_URL", "wss://connect.bringyour.com")
 	cfg.userAuth = pick("--user-auth", "USER_AUTH", "")
@@ -212,22 +212,24 @@ Options:
 		}()
 
 		socksProxy := proxy.NewSocksProxyWithDefaults()
-		// a dev tool: any credentials are accepted
-		socksProxy.ValidUser = func(user string, password string, userAddr string) bool {
-			return true
-		}
 		socksProxy.ConnectDialWithRequest = func(ctx context.Context, r proxy.SocksRequest, network string, addr string) (net.Conn, error) {
 			fmt.Println("Dialing", network, addr, r.DestAddr.FQDN)
 			return dev.DialContext(ctx, network, addr)
 		}
 
-		go socksProxy.ListenAndServe(ctx, "tcp", cfg.addr)
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- socksProxy.ListenAndServe(ctx, "tcp", cfg.addr)
+		}()
 
 		fmt.Printf("socks5 server is listening on %s\n", cfg.addr)
 
-		<-ctx.Done()
-
-		return nil
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-errCh:
+			return err
+		}
 	}
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/socks/main_test.go
+++ b/socks/main_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/docopt/docopt-go"
+)
+
+// This PR changed two things in main.go:
+//   - the socks5 dev server's default listen address, from the wildcard
+//     ":9999" to the loopback "127.0.0.1:9999" (both in the --help doc text
+//     and in the literal default passed to pick());
+//   - removed the dev tool's own "any credentials accepted" ValidUser
+//     override, relying instead on the proxy library's documented
+//     nil-ValidUser no-auth default.
+//
+// Neither cfg nor pick() nor the usage string are exported (they are locals
+// inside func main), so these tests read this package's own main.go source to
+// exercise the real, current text/literals rather than a copy that could
+// drift from it.
+
+// usageFromSource extracts the literal `usage := \`...\`` doc string from
+// main.go.
+func usageFromSource(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+
+	m := regexp.MustCompile("(?s)usage := `(.*?)`").FindStringSubmatch(string(data))
+	if m == nil {
+		t.Fatal("could not find the usage doc string in main.go")
+	}
+	return m[1]
+}
+
+// TestUsageDocumentsLoopbackAddrDefault pins the --help text change: the
+// --addr line must document the new loopback default, not the old wildcard
+// one.
+func TestUsageDocumentsLoopbackAddrDefault(t *testing.T) {
+	usage := usageFromSource(t)
+
+	var addrLine string
+	for _, line := range strings.Split(usage, "\n") {
+		if strings.Contains(line, "--addr=<addr>") {
+			addrLine = line
+			break
+		}
+	}
+	if addrLine == "" {
+		t.Fatal("usage doc has no --addr=<addr> line")
+	}
+	if !strings.Contains(addrLine, "default 127.0.0.1:9999") {
+		t.Fatalf("--addr doc = %q, want it to document default 127.0.0.1:9999", addrLine)
+	}
+	if strings.Contains(addrLine, "default :9999") {
+		t.Fatalf("--addr doc = %q, still documents the old wildcard default", addrLine)
+	}
+}
+
+// TestUsageStillParsesWithDocopt is a sanity check that the doc string edited
+// by this PR is still valid docopt syntax and --addr is still parsed as an
+// ordinary flag. The "(env ADDR, default ...)" text is documentation only --
+// docopt does not apply it -- so the actual default is checked separately by
+// TestAddrDefaultLiteralIsLoopback below.
+func TestUsageStillParsesWithDocopt(t *testing.T) {
+	usage := usageFromSource(t)
+
+	opts, err := docopt.ParseArgs(usage, []string{
+		"--addr", "10.0.0.1:1234",
+		"--user-auth", "u",
+		"--password", "p",
+	}, "test")
+	if err != nil {
+		t.Fatalf("ParseArgs: %v", err)
+	}
+	got, ok := opts["--addr"].(string)
+	if !ok || got != "10.0.0.1:1234" {
+		t.Fatalf("--addr = %v (ok=%v), want 10.0.0.1:1234", opts["--addr"], ok)
+	}
+}
+
+// TestAddrDefaultLiteralIsLoopback pins the functional half of the change:
+// the literal default passed to pick() for --addr/ADDR, which is what
+// actually determines the listen address when neither the flag nor the env
+// var is set.
+func TestAddrDefaultLiteralIsLoopback(t *testing.T) {
+	data, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+
+	m := regexp.MustCompile(`cfg\.addr = pick\("--addr", "ADDR", "([^"]*)"\)`).FindStringSubmatch(string(data))
+	if m == nil {
+		t.Fatal("could not find the cfg.addr default assignment in main.go")
+	}
+	if got := m[1]; got != "127.0.0.1:9999" {
+		t.Fatalf("addr default literal = %q, want 127.0.0.1:9999", got)
+	}
+}
+
+// TestDevSocksProxyHasNoValidUserOverride pins the removal of the
+// unconditional "any credentials accepted" ValidUser override that used to
+// follow NewSocksProxyWithDefaults(). With it gone, SocksProxy.ValidUser stays
+// nil, which proxy.SocksProxy now documents (and socks_test.go's
+// TestSocksProxyNilValidUserAllowsNoAuthEndToEnd verifies) as "allow no-auth"
+// -- the same effective behavior, expressed via the library default instead
+// of a copy of it living in this dev tool.
+func TestDevSocksProxyHasNoValidUserOverride(t *testing.T) {
+	data, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	src := string(data)
+
+	start := strings.Index(src, "NewSocksProxyWithDefaults()")
+	if start == -1 {
+		t.Fatal("could not find NewSocksProxyWithDefaults() call in main.go")
+	}
+	rest := src[start:]
+	end := strings.Index(rest, "ConnectDialWithRequest")
+	if end == -1 {
+		t.Fatal("could not find ConnectDialWithRequest assignment after NewSocksProxyWithDefaults()")
+	}
+	between := rest[:end]
+
+	if strings.Contains(between, "ValidUser") {
+		t.Fatalf("found a ValidUser assignment between NewSocksProxyWithDefaults() and "+
+			"ConnectDialWithRequest; the dev \"any credentials accepted\" override should "+
+			"have been removed in favor of the library's nil-ValidUser no-auth default:\n%s", between)
+	}
+}

--- a/socks_test.go
+++ b/socks_test.go
@@ -86,6 +86,250 @@ func TestSocksProxyClosesClientWhenUpstreamCloses(t *testing.T) {
 	}
 }
 
+// --- read-only accessors do not build/freeze the server ------------------
+
+// TestSocksProxyStatsBeforeServerBuiltReturnsZeroValue guards Stats' new
+// contract: before anything has built the server, Stats must return the zero
+// value rather than building it just to read counters.
+func TestSocksProxyStatsBeforeServerBuiltReturnsZeroValue(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+
+	if got := proxy.Stats(); got != (SocksStatsSnapshot{}) {
+		t.Fatalf("Stats before build = %+v, want zero value", got)
+	}
+}
+
+// TestSocksProxyActiveCountBeforeServerBuiltReturnsZero mirrors the Stats
+// case for ActiveCount.
+func TestSocksProxyActiveCountBeforeServerBuiltReturnsZero(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+
+	if got := proxy.ActiveCount(); got != 0 {
+		t.Fatalf("ActiveCount before build = %d, want 0", got)
+	}
+}
+
+// TestSocksProxyReadOnlyAccessorsDoNotFreezeConfiguration is the regression
+// test for the bug this PR fixes: Stats/ActiveCount used to call ensureServer,
+// which freezes Settings()/ValidUser/ConnectDialWithRequest at whatever they
+// were when first read. That meant merely observing a counter before serving
+// started could silently lock in stale configuration. This test reads both
+// accessors first, confirms they did not build the server, THEN sets
+// ValidUser, and proves the late-set ValidUser still takes effect once
+// serving actually starts.
+func TestSocksProxyReadOnlyAccessorsDoNotFreezeConfiguration(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+
+	if s := proxy.builtServer(); s != nil {
+		t.Fatal("server built before any use")
+	}
+	if got := proxy.Stats(); got != (SocksStatsSnapshot{}) {
+		t.Fatalf("Stats before build = %+v, want zero value", got)
+	}
+	if got := proxy.ActiveCount(); got != 0 {
+		t.Fatalf("ActiveCount before build = %d, want 0", got)
+	}
+	if s := proxy.builtServer(); s != nil {
+		t.Fatal("Stats/ActiveCount must not build the server")
+	}
+
+	// configure ValidUser only AFTER the read-only accessors above ran
+	const user, pass = "lateuser", "latepass"
+	proxy.ValidUser = func(u, p, addr string) bool { return u == user && p == pass }
+	echo := startTCPEcho(t)
+	proxy.ConnectDialWithRequest = func(ctx context.Context, r SocksRequest, network string, addr string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", echo)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := freeTCPAddr(t)
+	errCh := make(chan error, 1)
+	go func() { errCh <- proxy.ListenAndServe(ctx, "tcp", addr) }()
+	waitForTCP(t, addr)
+
+	if s := proxy.builtServer(); s == nil {
+		t.Fatal("server must be built once serving starts")
+	}
+
+	tc := dialClient(t, addr)
+	defer tc.close()
+	tc.negotiateUserPass(user, pass)
+	rep, _ := tc.request(cmdConnect, &AddrSpec{IP: net.IPv4(1, 2, 3, 4).To4(), Port: 80})
+	if rep != repSuccess {
+		t.Fatalf("connect reply = %#x, want success: ValidUser set after the "+
+			"read-only accessors did not take effect", rep)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndServe did not return after cancel")
+	}
+}
+
+// --- newServer: nil ValidUser preserves no-auth ---------------------------
+
+func TestNewServerNilValidUserLeavesServerValidUserNil(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+	// ValidUser left nil deliberately
+
+	server := proxy.newServer()
+
+	if server.ValidUser != nil {
+		t.Fatal("server.ValidUser must be nil when SocksProxy.ValidUser is nil, to preserve no-auth")
+	}
+}
+
+func TestNewServerNonNilValidUserDelegatesToConfiguredCallback(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+	proxy.ValidUser = func(user, password, userAddr string) bool {
+		return user == "alice" && password == "secret"
+	}
+
+	server := proxy.newServer()
+
+	if server.ValidUser == nil {
+		t.Fatal("server.ValidUser must be set when SocksProxy.ValidUser is non-nil")
+	}
+	if !server.ValidUser("alice", "secret", "1.2.3.4") {
+		t.Fatal("server.ValidUser must accept the configured credentials")
+	}
+	if server.ValidUser("bob", "wrong", "1.2.3.4") {
+		t.Fatal("server.ValidUser must reject credentials the callback rejects")
+	}
+}
+
+// TestNewServerValidUserPanicRecoversToFalse guards the connect.HandleError1
+// wrapping: a panicking ValidUser must not crash the server, and must be
+// treated as a rejected login.
+func TestNewServerValidUserPanicRecoversToFalse(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+	proxy.ValidUser = func(user, password, userAddr string) bool {
+		panic("boom")
+	}
+
+	server := proxy.newServer()
+
+	if got := server.ValidUser("u", "p", "addr"); got {
+		t.Fatal("server.ValidUser must return false when the callback panics, not propagate the panic")
+	}
+}
+
+// --- end-to-end through the public SocksProxy API -------------------------
+
+// TestSocksProxyNilValidUserAllowsNoAuthEndToEnd exercises the nil-ValidUser
+// path through the real SocksProxy wiring (not the raw socksServer), matching
+// how socks/main.go's dev tool now relies on the library default instead of
+// its own "accept everything" override.
+func TestSocksProxyNilValidUserAllowsNoAuthEndToEnd(t *testing.T) {
+	echo := startTCPEcho(t)
+
+	proxy := NewSocksProxy(testSocksSettings())
+	// ValidUser left nil deliberately: no-auth must be offered and accepted.
+	proxy.ConnectDialWithRequest = func(ctx context.Context, r SocksRequest, network string, addr string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", echo)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := freeTCPAddr(t)
+	errCh := make(chan error, 1)
+	go func() { errCh <- proxy.ListenAndServe(ctx, "tcp", addr) }()
+	waitForTCP(t, addr)
+
+	tc := dialClient(t, addr)
+	defer tc.close()
+	tc.negotiateNoAuth()
+	rep, _ := tc.request(cmdConnect, &AddrSpec{IP: net.IPv4(1, 2, 3, 4).To4(), Port: 80})
+	if rep != repSuccess {
+		t.Fatalf("connect reply = %#x, want success", rep)
+	}
+	tc.mustWrite([]byte("ping"))
+	if got := string(tc.mustRead(4)); got != "ping" {
+		t.Fatalf("echo = %q, want ping", got)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndServe did not return after cancel")
+	}
+}
+
+// TestSocksProxyValidUserPanicRecoversAsAuthFailureEndToEnd is the negative
+// counterpart: a panicking ValidUser, wired through the real SocksProxy, must
+// surface to the wire as an ordinary auth failure rather than taking down the
+// connection or the server.
+func TestSocksProxyValidUserPanicRecoversAsAuthFailureEndToEnd(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+	proxy.ValidUser = func(user, password, userAddr string) bool {
+		panic("boom")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := freeTCPAddr(t)
+	errCh := make(chan error, 1)
+	go func() { errCh <- proxy.ListenAndServe(ctx, "tcp", addr) }()
+	waitForTCP(t, addr)
+
+	tc := dialClient(t, addr)
+	defer tc.close()
+	tc.mustWrite([]byte{socksVersion, 1, methodUserPass})
+	if resp := tc.mustRead(2); resp[0] != socksVersion || resp[1] != methodUserPass {
+		t.Fatalf("method select = % x", resp)
+	}
+	auth := []byte{userPassVersion, 1, 'u', 1, 'p'}
+	tc.mustWrite(auth)
+	ar := tc.mustRead(2)
+	if ar[0] != userPassVersion || ar[1] != authFailure {
+		t.Fatalf("auth resp = % x, want auth failure: panic must not crash the connection", ar)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndServe did not return after cancel")
+	}
+}
+
+// TestSocksProxyNoAuthClientRejectedWhenValidUserSet pins the auth side of
+// the negotiation: when ValidUser is set, a client offering only no-auth
+// (method 0x00) must be rejected with no-acceptable-methods (0xff) rather
+// than silently relayed.
+func TestSocksProxyNoAuthClientRejectedWhenValidUserSet(t *testing.T) {
+	proxy := NewSocksProxy(testSocksSettings())
+	proxy.ValidUser = func(user, password, userAddr string) bool {
+		return true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := freeTCPAddr(t)
+	errCh := make(chan error, 1)
+	go func() { errCh <- proxy.ListenAndServe(ctx, "tcp", addr) }()
+	waitForTCP(t, addr)
+
+	tc := dialClient(t, addr)
+	defer tc.close()
+	tc.mustWrite([]byte{socksVersion, 1, methodNoAuth})
+	if resp := tc.mustRead(2); resp[0] != socksVersion || resp[1] != methodNoAcceptable {
+		t.Fatalf("method select = % x, want no-acceptable-methods (0xff)", resp)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndServe did not return after cancel")
+	}
+}
+
 func startSocksProxy(t *testing.T, dial func(context.Context, SocksRequest, string, string) (net.Conn, error)) (string, func()) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

The v2026 SOCKS5 rewrite (`b281b8d`) changed listen-port auth semantics. `newServer()` always installed a credential validator that rejected *every* client when the app set no `ValidUser`, and `socks/main.go` forced user/pass-only negotiation via a dev-tool placeholder that accepted any credentials. Clients offering no auth (e.g. Firefox pointed at the local port with empty credentials) were rejected with "no acceptable authentication methods".

This contradicts the design doc shipped with the rewrite (`SOCKS.md`): `ValidUser func(user, pass, userAddr string) bool // nil => no-auth allowed`, and the compat table row "Auth | no-auth + username/password via `ValidUser` | Preserves current behavior".

## Changes

1. **`socks.go`: nil `ValidUser` means no-auth.** The credential validator is only attached when the app sets one; nil offers no-auth, exactly as before the rewrite. When set, behavior is unchanged (RFC 1929 enforcement, panics recovered via `connect.HandleError`).
2. **`socks.go`: callbacks captured at server build.** `ConnectDialWithRequest`/`ValidUser` were read dynamically inside the closures on every invocation, racing a concurrent assignment. Both are captured at build time, making the documented configuration freeze atomic with the build (fixes a data race).
3. **`socks.go`: read-only accessors no longer freeze configuration.** `Stats()`/`ActiveCount()` called `ensureServer()`, which froze the config (including `ValidUser`) at the first read — a caller reading a counter during setup could permanently disable auth before assigning `ValidUser`. They now return zero values until the server exists; only `Drain()`/`WaitIdle()` build it.
4. **`socks/main.go`: loopback default.** `--addr` now defaults to `127.0.0.1:9999` instead of `:9999`, so an unauthenticated listen port is not exposed to every reachable host. An explicit `--addr` still allows wider exposure.
5. **`socks/main.go`: surface bind errors.** `ListenAndServe`'s error was dropped and the process hung on `<-ctx.Done()`; a bind failure (e.g. port in use) now propagates and exits non-zero.
6. **`socks_test.go`: regression coverage.** nil `ValidUser` accepts a no-auth client end to end; set `ValidUser` rejects no-auth and bad credentials, accepts valid ones, and recovers from a panicking validator; `Stats()`/`ActiveCount()` before `ValidUser` assignment no longer freeze the configuration. All run clean under `-race`.

## Verification

- `go test ./...` and targeted socks tests pass on Linux, including `-race`.
- Unit-level handshake coverage (no-auth accepted when `ValidUser` nil; rejected when set; panic recovery; non-freezing accessors).
- End-to-end confirmed by operators on two Windows test machines: fixed binary with `--addr 0.0.0.0:9999 --user-auth/--password/--country`; Firefox SOCKS5 `127.0.0.1:9999` with empty credentials works; `curl --socks5` without `--proxy-user` works.