### PR TITLE
ci: build and test proxy on every push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,14 @@ on:
 permissions:
   contents: read
 
+# connect/test.yml and sdk/test.yml (the two oldest) set no concurrency group,
+# so a busy branch stacks runs there. server/test.yml and linux/build.yml (the
+# two newest) do, and this follows the newer habit: a superseded run is
+# cancelled rather than left burning a runner for a commit nobody will look at.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: go test
@@ -51,9 +59,17 @@ jobs:
           go-version-file: proxy/go.mod
           cache-dependency-path: proxy/go.sum
 
+      # Builds the library and the socks command in one pass -- socks/ is a main
+      # package inside this same module, not a separate one.
       - name: Build
         working-directory: proxy
         run: go build ./...
+
+      # Cheap, and it catches the class of mistake a compile does not: lost
+      # cancels, copied locks, printf mismatches. server/test.yml runs it too.
+      - name: Vet
+        working-directory: proxy
+        run: go vet ./...
 
       # -count=1 defeats the test result cache so a green run always means the
       # tests actually ran. The suite needs no privileges and no external

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,67 @@
+name: Test — proxy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: go test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out proxy
+        uses: actions/checkout@v4
+        with:
+          path: proxy
+
+      # go.mod resolves connect, userwireguard and glog through `replace ../`,
+      # so a lone checkout does not build. It fails at the module load with
+      # "replacement directory ../connect does not exist" -- all three siblings
+      # must sit beside the checkout under exactly these directory names.
+      #
+      # glog is here even though proxy only lists it as indirect: connect's own
+      # go.mod replaces glog with ../glog, and that path resolves from the
+      # workspace root once connect is checked out as a sibling.
+      #
+      # Each sibling is taken at its default branch, the same thing a developer
+      # gets following the README. Note userwireguard's default branch is
+      # master, not main -- omitting `ref:` gets that right by itself, where
+      # hardcoding main would not.
+      - name: Check out connect dependency
+        uses: actions/checkout@v4
+        with: { repository: urnetwork/connect, path: connect }
+      - name: Check out glog dependency
+        uses: actions/checkout@v4
+        with: { repository: urnetwork/glog, path: glog }
+      - name: Check out userwireguard dependency
+        uses: actions/checkout@v4
+        with: { repository: urnetwork/userwireguard, path: userwireguard }
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: proxy/go.mod
+          cache-dependency-path: proxy/go.sum
+
+      - name: Build
+        working-directory: proxy
+        run: go build ./...
+
+      # -count=1 defeats the test result cache so a green run always means the
+      # tests actually ran. The suite needs no privileges and no external
+      # network: every case is loopback -- echo servers on 127.0.0.1 against a
+      # userspace wireguard, so no TUN device and no root. It takes ~1 min, most
+      # of it the restart (~60s) and endpoint handoff (~30s) recovery tests,
+      # which is why -short is deliberately not passed: those are the tests
+      # worth having.
+      - name: Test
+        working-directory: proxy
+        run: go test -count=1 -timeout 20m ./...


### PR DESCRIPTION
proxy is one of the urnetwork repos with no CI of its own. This adds the first one: a push, a PR against `main`, or a manual dispatch now compiles every package and runs the real test suite.

### What it runs

`go build ./...` then `go test -count=1 -timeout 20m ./...`, on `ubuntu-latest`, with `actions/checkout@v4` and `actions/setup-go@v5`.

### This is the one in the set that needs siblings

`go.mod` resolves `connect`, `userwireguard` and `glog` through `replace ../`, so a lone checkout does not build. It fails at module load:

```
http.go:18:2: github.com/urnetwork/connect@v0.0.0: replacement directory ../connect does not exist
wg.go:14:2:  github.com/urnetwork/userwireguard@v0.0.0: replacement directory ../userwireguard does not exist
```

The layout copies `server`'s workflow rather than inventing one: this repo is checked out under `path: proxy`, with the three siblings beside it under exactly the directory names the replace directives target.

Three details a reviewer should check:

- **`glog` is checked out even though `proxy` only lists it as indirect.** `connect`'s own `go.mod` replaces `glog` with `../glog`, and that path resolves from the workspace root once `connect` is a sibling. Drop it and the build fails inside `connect`.
- **`userwireguard`'s default branch is `master`, not `main`.** Omitting `ref:` gets that right by itself. Hardcoding `main` — the obvious thing to write — would fail. (`glog` is `master` too.)
- **Siblings float on their default branch**, the same thing a developer gets following the README. That is `server`'s existing tradeoff, inherited deliberately: it means an unrelated push to `connect` can turn open PRs here red. If that proves noisy, pin `ref:` per sibling and bump on purpose.

`goidenticons` is *not* needed here — it is not in this module's graph, direct or indirect — so unlike `sdk`'s workflow there is no `RenderPngV2` shim in this file.

### Toolchain

`go-version-file: proxy/go.mod` with `cache-dependency-path: proxy/go.sum`, matching `server`'s workflow. That pins CI to the Go version the module actually declares (`1.26.3`) instead of drifting with `stable`. Confirmed `1.26.3` is still resolvable by `actions/setup-go` — it is present in both the `actions/go-versions` manifest and `go.dev/dl`.

### These are real tests

The suite needs no privileges and no external network: every case is loopback — echo servers on `127.0.0.1` against a userspace wireguard, so no TUN device and no root, and no secret is referenced anywhere in this workflow. It covers the SOCKS5 server and codec, UDP associate, connection and flow leak accounting, half-close, drain, abort, relay, and wireguard restart/handoff/removal recovery.

`-short` is deliberately **not** passed. The restart (~60s) and endpoint handoff (~30s) recovery tests skip under it, and those are the tests worth having. The whole job is ~1 min of test time.

### Verification

Run locally against `17f929c` (current `main`) with the three siblings checked out at their default branches, under **both** Go 1.27.0 and Go 1.26.3 (the exact `go.mod` pin):

```
ok  github.com/urnetwork/proxy        51.054s
ok  github.com/urnetwork/proxy/socks   0.004s
```

`actionlint` is clean on the file.

Draft: opened alongside the equivalent PRs for `glog`, `warp` and `goidenticons` so they can be reviewed as one set.